### PR TITLE
Update maak8s-kube-api-alias.sh

### DIFF
--- a/kubernetes-maa/maak8s-kube-api-alias.sh
+++ b/kubernetes-maa/maak8s-kube-api-alias.sh
@@ -65,7 +65,7 @@ done
 
 echo "Restarting control plane..."
 $basedir/maak8s-force-stop-cp.sh "$MNODE_LIST"
-sleep 5
+sleep 15
 for host in ${MNODE_LIST}; do
 	ssh -i $ssh_key $user@$host "sudo systemctl restart kubelet"
 	ssh -i $ssh_key $user@$host "sudo kubeadm init phase upload-config kubeadm --config $kubeadmyaml"


### PR DESCRIPTION
Seems like the firts control plane node is still coming up for the first upload of config, so adding a few more seconds to the sleep