### PR TITLE
Restart on restore changes

### DIFF
--- a/kubernetes-maa/maak8-etcd-restore.sh
+++ b/kubernetes-maa/maak8-etcd-restore.sh
@@ -206,6 +206,11 @@ if ($backups_exist == "true" ); then
         	        done
 			listofns=$(kubectl --kubeconfig=$kcfg get ns | grep -v NAME | awk '{print $1}')
 			for ns in ${listofns}; do
+				listofdaemonsets=$(kubectl --kubeconfig=$kcfg get ds -n $ns | grep -v NAME | awk '{print $1}')
+                                for daemonset in ${listofdaemonsets}; do
+                                        echo "Restarting daemonset $daemonset"
+                                        kubectl --kubeconfig=$kcfg rollout restart -n $ns  ds/$daemonset
+                                done
 				listofdeploy=$(kubectl --kubeconfig=$kcfg get deployments -n $ns | grep -v NAME | awk '{print $1}')
 	        		for deploy in ${listofdeploy}; do
 					echo "Restarting deployment $deploy"

--- a/kubernetes-maa/maak8s.env
+++ b/kubernetes-maa/maak8s.env
@@ -1,9 +1,9 @@
 #bastion node or node that can kubectl to the cluster
-export bastion_node=olk8-m1
+export bastion_node=olk8-bastion
 #sudo ready user to ssh into bastion node
 export user=opc
 #ssh key for the ssh
-export ssh_key=/home/opc/KeyWithoutPassPhraseSOAMAA.ppk
+export ssh_key=/home/opc/k8sMAA.ppk
 #etcdctl executable's location
 export etcdctlhome=/scratch/docker/etcdctl/
 
@@ -13,5 +13,5 @@ export advert_port=2379
 export init_port=2380
 
 #infrastructure pods that will be restarted  on restore
-export infra_pod_list="flannel proxy controller scheduler"
+export infra_pod_list="proxy controller scheduler"
 


### PR DESCRIPTION
Now we are restarting flannel and kube-proxy through daemonset roll restart. We do it before deployments so that coredns picks up appropriate proxy and flannel status