### PR TITLE
Update replacement_script_BVmodel.sh

### DIFF
--- a/wls_mp_dr/Block_Volume_Replica_Method/replacement_script_BVmodel/replacement_script_BVmodel.sh
+++ b/wls_mp_dr/Block_Volume_Replica_Method/replacement_script_BVmodel/replacement_script_BVmodel.sh
@@ -83,8 +83,8 @@ replace_tnsnamesora_tnsadmin(){
 
 
 remove_tmp_lck_files(){
-	rm ${DOMAIN_HOME}/servers/*/data/nodemanager/*.lck
-	rm ${DOMAIN_HOME}/servers/*/data/nodemanager/*.state
+	rm -f ${DOMAIN_HOME}/servers/*/data/nodemanager/*.lck
+	rm -f ${DOMAIN_HOME}/servers/*/data/nodemanager/*.state
 }
 
 


### PR DESCRIPTION
Added -f flag to the remove command of the .lck and .state files, to avoid an error in case they don't exist.  Without this, when there are no .lck or .state files in that path, the rm commands give an error message. If you are running the script via an orchestrator (like FSDR), the output is considered a script failure.