### PR TITLE
Update README.md

### DIFF
--- a/wls-hydr/README.md
+++ b/wls-hydr/README.md
@@ -143,7 +143,8 @@ Run the following steps as preparation for the execution of the scripts in all s
 2. Create a subnet in the VCN for the bastion. 
 3. Provision a bastion host in the subnet. The bastion host must use OL8 or OL9. A "VM.Standard.E4.Flex with 1 OCPU and 16GB memory" shape is enough to run the framework. The amount of information that is copied to the bastion can be high (around 40GB for the typical FMW SOA product and config directories), so you can attach an additional block volume of this size during the bastion creation process itself. You can use this formula for a rough estimate of the required storage size: _[2xFMW products] + [WLS_domain_size x (nº wls nodes + 1)] + [2xOHS products] + [OHS domain_size x (nº of OHS nodes)]_
 4. For the "COMPLETE DR SETUP" use case, setup connectivity between primary hosts and the bastion host (FastConnect, VPN, Peering). This is not required if you are performing a "BACKUP AND RESTORE TO OCI".
-5. Prepare the bastion host to run the framework:
+5. Download the WLS_HYDR framework to the bastion server (example location <HOME>/wls_hydr).
+6. Prepare the bastion host to run the framework:
     1. Make sure pip is installed and updated:  
     `sudo yum install python3-pip`  
     `sudo python3 -m pip install --upgrade pip`  
@@ -151,7 +152,6 @@ Run the following steps as preparation for the execution of the scripts in all s
     `cd /path/to/wls_hydr`  
     `python3 -m pip install -r requirements.txt`  
     3. Add the OCI config to the bastion server. This is needed to connect through OCI APIs to the OCI tenancy and region where you want to create the resources. The complete instructions can be found [here](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#apisigningkey_topic_How_to_Generate_an_API_Signing_Key_Console). Then, when you run the provisioning phase, you can supply the path of the oci config file using -c/--oci-config FILE_PATH. If no path is supplied, the default path is assumed `<HOME>/.oci/config` 
-6. Download the WLS_HYDR framework to the bastion server (example location <HOME>/wls_hydr) 
 7. (Optional) Create a subnet for the database if the WLS/FMW domain is using one.
 8. (Optional) Create a peer DB system if the WLS domain is using one:
     - For the "COMPLETE DR SETUP" Data Guard should be configured before or after running the WLS_HYDR framework. Refer to the steps at https://docs.oracle.com/en/solutions/configure-standby-db/index.html. The WLS_HYDR framework does not set up connectivity between the middle tier and the database in OCI. 


### PR DESCRIPTION
Corrected the order in the prepare steps: moved the step to download the WLS_HYDR framework before the pip commands, because these commands require the framework files.